### PR TITLE
Replace getentropy with arc4random_buf

### DIFF
--- a/lib/Crypt/SysRandom/XS.pm
+++ b/lib/Crypt/SysRandom/XS.pm
@@ -37,6 +37,10 @@ At build-time, it will try the following backends in order:
 
 This backend is available on Linux, FreeBSD and Solaris
 
+=item * arc4random
+
+This interface is supported on most BSDs and Mac.
+
 =item * BCryptGenRandom
 
 This backend is available on Windows (Vista and newer)

--- a/lib/Crypt/SysRandom/XS.pm
+++ b/lib/Crypt/SysRandom/XS.pm
@@ -37,10 +37,6 @@ At build-time, it will try the following backends in order:
 
 This backend is available on Linux, FreeBSD and Solaris
 
-=item * getentropy
-
-This backend is standardized in POSIX and is available on most modern unixes
-
 =item * BCryptGenRandom
 
 This backend is available on Windows (Vista and newer)

--- a/lib/Crypt/SysRandom/XS.xs
+++ b/lib/Crypt/SysRandom/XS.xs
@@ -10,13 +10,7 @@
 #include <sys/types.h>
 #include <errno.h>
 
-#if defined(HAVE_SYS_RANDOM_GETENTROPY)
-#include <sys/random.h>
-
-#elif defined(HAVE_UNISTD_GETENTROPY)
-#include <unistd.h>
-
-#elif defined(HAVE_SYS_RANDOM_GETRANDOM)
+#if defined(HAVE_SYS_RANDOM_GETRANDOM)
 #include <sys/random.h>
 
 #elif defined(HAVE_SYSCALL_GETRANDOM)
@@ -52,13 +46,7 @@ SV* random_bytes(size_t wanted)
 		SvGROW(RETVAL, wanted + 1);
 		SvCUR_set(RETVAL, wanted);
 		char* data = SvPVX(RETVAL);
-#if defined(HAVE_SYS_RANDOM_GETENTROPY) || defined(HAVE_UNISTD_GETENTROPY)
-		int result = getentropy(data, wanted);
-		if (result < 0) {
-			SvREFCNT_dec(RETVAL);
-			croak(error_string);
-		}
-#elif defined(HAVE_BCRYPT_GENRANDOM)
+#if defined(HAVE_BCRYPT_GENRANDOM)
 		NTSTATUS status = BCryptGenRandom(NULL, data, wanted, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
 		if (!NT_SUCCESS(status)) {
 			SvREFCNT_dec(RETVAL);

--- a/lib/Crypt/SysRandom/XS.xs
+++ b/lib/Crypt/SysRandom/XS.xs
@@ -10,13 +10,19 @@
 #include <sys/types.h>
 #include <errno.h>
 
-#if defined(HAVE_SYS_RANDOM_GETRANDOM)
+#if defined(HAVE_SYS_RANDOM_GETRANDOM) || defined(HAVE_SYS_RANDOM_ARC4RANDOM)
 #include <sys/random.h>
 
 #elif defined(HAVE_SYSCALL_GETRANDOM)
 #include <sys/syscall.h>
 #include <unistd.h>
 #define getrandom(data, length, flags) syscall(SYS_getrandom, data, length, flags)
+
+#elif defined(HAVE_UNISTD_ARC4RANDOM)
+#include <unistd.h>
+
+#elif defined(HAVE_STDLIB_ARC4RANDOM)
+#include <stdlib.h>
 
 #elif defined(HAVE_BCRYPT_GENRANDOM)
 #define WIN32_NO_STATUS
@@ -52,6 +58,8 @@ SV* random_bytes(size_t wanted)
 			SvREFCNT_dec(RETVAL);
 			croak(error_string);
 		}
+#elif defined(HAVE_SYS_RANDOM_ARC4RANDOM) || defined(HAVE_UNISTD_ARC4RANDOM) || defined(HAVE_STDLIB_ARC4RANDOM)
+		arc4random_buf(data, wanted);
 #elif defined(HAVE_RDRAND64)
 		if (wanted % 8)
 			SvGROW(RETVAL, wanted + (8 - (wanted % 8)) + 1);

--- a/planner/xs.pl
+++ b/planner/xs.pl
@@ -32,27 +32,6 @@ int main(void)
         return 0;
 }
 EOF
-	['getentropy in sys/random.h', 'SYS_RANDOM_GETENTROPY', {}, <<EOF ],
-#include <sys/types.h>
-#include <sys/random.h>
-
-int main(void)
-{
-        char buf[16];
-        int r = getentropy(buf, sizeof(buf));
-        return 0;
-}
-EOF
-	['getentropy in unistd.h', 'UNISTD_GETENTROPY', {}, <<EOF ],
-#include <unistd.h>
-
-int main(void)
-{
-        char buf[16];
-        int r = getentropy(buf, sizeof(buf));
-        return 0;
-}
-EOF
 	['Microsoft BcryptGenRandom', 'BCRYPT_GENRANDOM', { libraries => ['Bcrypt'] }, <<EOF ],
 #define WIN32_NO_STATUS
 #include <windows.h>

--- a/planner/xs.pl
+++ b/planner/xs.pl
@@ -32,6 +32,37 @@ int main(void)
         return 0;
 }
 EOF
+	['arc4random in sys/random.h', 'SYS_RANDOM_ARC4RANDOM', {}, <<EOF ],
+#include <sys/types.h>
+#include <sys/random.h>
+
+int main(void)
+{
+        char buf[16];
+        arc4random_buf(buf, sizeof(buf));
+        return 0;
+}
+EOF
+	['arc4random in unistd.h', 'UNISTD_ARC4RANDOM', {}, <<EOF ],
+#include <unistd.h>
+
+int main(void)
+{
+        char buf[16];
+        arc4random_buf(buf, sizeof(buf));
+        return 0;
+}
+EOF
+	['arc4random in stdlib.h', 'STDLIB_ARC4RANDOM', {}, <<EOF ],
+#include <stdlib.h>
+
+int main(void)
+{
+        char buf[16];
+        arc4random_buf(buf, sizeof(buf));
+        return 0;
+}
+EOF
 	['Microsoft BcryptGenRandom', 'BCRYPT_GENRANDOM', { libraries => ['Bcrypt'] }, <<EOF ],
 #define WIN32_NO_STATUS
 #include <windows.h>


### PR DESCRIPTION
`getentropy` has some annoying behavior, in particular it only allows for 256 byte reads #2. While more should rarely be needed, it is an annoying limitation.

This branch replaces it with `arc4random`, which is more suitable when one needs large amounts of random data. This works well on BSD and Mac